### PR TITLE
chore: Renamed unconventional variables

### DIFF
--- a/src/pages/[page].tsx
+++ b/src/pages/[page].tsx
@@ -26,12 +26,12 @@ export const getStaticPaths: GetStaticPaths<IPageUrl> = async () => {
   const pages = convertTo2D(posts, AppConfig.pagination_size);
 
   return {
-    paths: pages.slice(1).map((_, ind) => ({
+    paths: pages.slice(1).map((_, index) => ({
       params: {
-        // Ind starts from zero so we need to do ind + 1
-        // slice(1) removes the first page so we do another ind + 1
+        // Index starts from zero so we need to do index + 1
+        // slice(1) removes the first page so we do another index + 1
         // the first page is implemented in index.tsx
-        page: `page${ind + 2}`,
+        page: `page${index + 2}`,
       },
     })),
     fallback: false,
@@ -46,7 +46,7 @@ export const getStaticProps: GetStaticProps<
 
   const pages = convertTo2D(posts, AppConfig.pagination_size);
   const currentPage = Number(params!.page.replace('page', ''));
-  const currentInd = currentPage - 1;
+  const currentIndex = currentPage - 1;
 
   const pagination: IPaginationProps = {};
 
@@ -62,7 +62,7 @@ export const getStaticProps: GetStaticProps<
 
   return {
     props: {
-      posts: pages[currentInd],
+      posts: pages[currentIndex],
       pagination,
     },
   };

--- a/src/utils/Pagination.ts
+++ b/src/utils/Pagination.ts
@@ -1,11 +1,11 @@
 export function convertTo2D<T>(arr: T[], size: number) {
   const res: T[][] = [];
 
-  arr.forEach((elt, ind) => {
-    if (ind % size === 0) {
-      res.push([elt]);
+  arr.forEach((element, index) => {
+    if (index % size === 0) {
+      res.push([element]);
     } else {
-      res[res.length - 1].push(elt);
+      res[res.length - 1].push(element);
     }
   });
 


### PR DESCRIPTION
I hope the team will grant me this indulgence. While working on the boilerplate, I encountered some variables that led to double takes due to their unconventional naming. To address this, I suggest using fully descriptive variable names and minimizing the use of abbreviations. This will greatly improve the code's readability and make it easier to work with.